### PR TITLE
feat: upgrade to Vertx5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@6
+    gravitee: gravitee-io/gravitee@6.0.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,32 +4,32 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@3.0.0
+    gravitee: gravitee-io/gravitee@6
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:
-  setup_build:
-    when:
-      not: << pipeline.git.tag >>
-    jobs:
-      - gravitee/setup_plugin-build-config:
-          filters:
-            tags:
-              ignore:
-                - /.*/
+    setup_build:
+        when:
+            not: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_plugin-build-config:
+                  filters:
+                      tags:
+                          ignore:
+                              - /.*/
 
-  setup_release:
-    when:
-      matches:
-        pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
-        value: << pipeline.git.tag >>
-    jobs:
-      - gravitee/setup_plugin-release-config:
-          filters:
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only:
-                - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/
+    setup_release:
+        when:
+            matches:
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
+                value: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_plugin-release-config:
+                  filters:
+                      branches:
+                          ignore:
+                              - /.*/
+                      tags:
+                          only:
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["github>gravitee-io/renovate-config:policy"]
+    "extends": ["github>gravitee-io/renovate-config:policy"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,10 @@
     <name>Gravitee IO - Access Management - Resource - Mock</name>
 
     <properties>
-        <gravitee-am.version>4.12.0-vertx-SNAPSHOT</gravitee-am.version>
-        <gravitee-bom.version>9.0.0-alpha.1</gravitee-bom.version>
-        <gravitee-plugin-api.version>4.10.1</gravitee-plugin-api.version>
-        <gravitee-node-api.version>5.21.2</gravitee-node-api.version>
+        <gravitee-am.version>4.12.0-alpha.1</gravitee-am.version>
+        <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
+        <gravitee-plugin-api.version>5.0.0-alpha.3</gravitee-plugin-api.version>
+        <gravitee-node-api.version>9.0.0-alpha.1</gravitee-node-api.version>
         <publish-folder-path>graviteeio-am/plugins/resources/</publish-folder-path>
         <gravitee.archrules.skip>true</gravitee.archrules.skip>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>25.0.0-alpha.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -39,11 +39,12 @@
     <name>Gravitee IO - Access Management - Resource - Mock</name>
 
     <properties>
-        <gravitee-am.version>4.6.5</gravitee-am.version>
-        <gravitee-bom.version>8.3.47</gravitee-bom.version>
+        <gravitee-am.version>4.12.0-vertx-SNAPSHOT</gravitee-am.version>
+        <gravitee-bom.version>9.0.0-alpha.1</gravitee-bom.version>
         <gravitee-plugin-api.version>4.10.1</gravitee-plugin-api.version>
         <gravitee-node-api.version>5.21.2</gravitee-node-api.version>
         <publish-folder-path>graviteeio-am/plugins/resources/</publish-folder-path>
+        <gravitee.archrules.skip>true</gravitee.archrules.skip>
     </properties>
 
     <dependencyManagement>

--- a/src/main/assembly/plugin-assembly.xml
+++ b/src/main/assembly/plugin-assembly.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/am/resource/mock/MFAResource.java
+++ b/src/main/java/io/gravitee/am/resource/mock/MFAResource.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/am/resource/mock/MFAResourceConfiguration.java
+++ b/src/main/java/io/gravitee/am/resource/mock/MFAResourceConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/am/resource/mock/provider/MFAMockProvider.java
+++ b/src/main/java/io/gravitee/am/resource/mock/provider/MFAMockProvider.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,12 +1,12 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:am:resource:mock:MFAResourceConfiguration",
-  "properties" : {
-    "code": {
-      "title": "Code",
-      "description": "Unique code verified by this mock resource",
-      "type": "string"
-    }
-  },
-  "required": ["code"]
+    "type": "object",
+    "id": "urn:jsonschema:io:gravitee:am:resource:mock:MFAResourceConfiguration",
+    "properties": {
+        "code": {
+            "title": "Code",
+            "description": "Unique code verified by this mock resource",
+            "type": "string"
+        }
+    },
+    "required": ["code"]
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/AM-6611

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-AM-6611-vertx-5-migration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/am/resource/mock/gravitee-am-resource-mfa-mock/2.0.0-AM-6611-vertx-5-migration-SNAPSHOT/gravitee-am-resource-mfa-mock-2.0.0-AM-6611-vertx-5-migration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-AM-6611-vertx-5-migration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/am/resource/mock/gravitee-am-resource-mfa-mock/2.0.0-AM-6611-vertx-5-migration-SNAPSHOT/gravitee-am-resource-mfa-mock-2.0.0-AM-6611-vertx-5-migration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
